### PR TITLE
add MCC (Brant, Stanley)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Conference, Year. [[Paper]](link) [[Code]](link) [[Website]](link)
 
 ## <a name="papers"></a> Papers
 
+* **Minimal Criterion Coevolution: A New Approach to Open-Ended Search** <br>
+*Jonathan C. Brant, Kenneth O. Stanley* <br>
+GECCO, 2017. [[Paper]](https://eplex.cs.ucf.edu/papers/brant_gecco17.pdf) [[Code]](https://github.com/jbrant/MinimalCriterionCoevolution)
+
 * **Paired Open-Ended Trailblazer (POET): Endlessly Generating Increasingly Complex and Diverse Learning Environments and Their Solutions** <br>
 *Rui Wang, Joel Lehman, Jeff Clune, Kenneth O. Stanley* <br>
 GECCO, 2019. [[Paper]](https://arxiv.org/abs/1901.01753) [[Code]](https://github.com/uber-research/poet) [[Website]](https://www.uber.com/en-CA/blog/poet-open-ended-deep-learning/)
@@ -153,4 +157,3 @@ arXiv, 2022. [[Paper]](https://arxiv.org/abs/2204.12639)
 * **General Intelligence Requires Rethinking Exploration** <br>
 *Minqi Jiang, Tim Rocktäschel, Edward Grefenstette* <br>
 Royal Society Open Science, 2023. [[Paper]](https://arxiv.org/abs/2211.07819)
-


### PR DESCRIPTION
Added one of the earliest known open-ended coevolution papers. 

With honorable mentions (to review - potentially within scope of list):

* **Diversity Preservation in Minimal Criterion Coevolution through Resource Limitation** <br>
*Jonathan C. Brant, Kenneth O. Stanley* <br>
GECCO, 2020. [[Paper]](https://eplex.cs.ucf.edu/papers/brant_gecco20.pdf) [[Code]](https://github.com/jbrant/MinimalCriterionCoevolution) <br>
Note: Introduced change to MCC by replacing speciation with resource limits, leading to simpler algorithm and improved performance.

* **Learning Quadrupedal Locomotion over Challenging Terrain** <br>
*Joonho Lee, Jemin Hwangbo, Lorenz Wellhausen, Vladlen Koltun, Marco Hutter* <br>
Science Robotics, 2020. [[Paper]](https://arxiv.org/abs/2010.11251) [[Code]](https://github.com/leggedrobotics/learning_quadrupedal_locomotion_over_challenging_terrain_supplementary) [[Website]](https://leggedrobotics.github.io/rl-blindloco/) <br>
Note: Strongly inspired by POET, with the difference that a generalist model is trained for a real-world robotics application (one of the earliest applications of environment design in physical robot domain)