### PR TITLE
Add DCEO paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ ICLR, 2023. [[Paper]](https://arxiv.org/abs/2211.13051) [[Website]](https://kvfr
 *Adaptive Agent Team, Jakob Bauer, Kate Baumli, Satinder Baveja, Feryal Behbahani, Avishkar Bhoopchand, Nathalie Bradley-Schmieg, Michael Chang, Natalie Clay, Adrian Collister, Vibhavari Dasagi, Lucy Gonzalez, Karol Gregor, Edward Hughes, Sheleem Kashem, Maria Loks-Thompson, Hannah Openshaw, Jack Parker-Holder, Shreya Pathak, Nicolas Perez-Nieves, Nemanja Rakicevic, Tim Rocktäschel, Yannick Schroecker, Jakub Sygnowski, Karl Tuyls, Sarah York, Alexander Zacherl, Lei Zhang* <br>
 ICML, 2023. [[Paper]](https://arxiv.org/abs/2301.07608) [[Website]](https://sites.google.com/view/adaptive-agent/)
 
+* **Deep Laplacian-based Options for Temporally-Extended Exploration** <br>
+*Martin Klissarov, Marlos C. Machado* <br>
+ICML, 2023. [[Paper]](https://arxiv.org/abs/2301.11181) [[Blogpost 1]](https://medium.com/@marlos.cholodovskis/the-representation-driven-option-discovery-cycle-e3f5877696c2) [[Blogpost2]](https://medium.com/@marlos.cholodovskis/deep-laplacian-based-options-for-temporally-extended-exploration-7bf8dd469838)
+
 * **Voyager: An Open-Ended Embodied Agent with Large Language Models** <br>
 *Guanzhi Wang, Yuqi Xie, Yunfan Jiang, Ajay Mandlekar, Chaowei Xiao, Yuke Zhu, Linxi Fan, Anima Anandkumar* <br>
 arXiv, 2023. [[Paper]](https://arxiv.org/abs/2305.16291) [[Code]](https://github.com/MineDojo/Voyager) [[Website]](https://voyager.minedojo.org/)


### PR DESCRIPTION
Add paper on Deep Covering Eigenoptions, which I think is a really interesting and promising method for discovering increasingly complex options in the continual learning setting 